### PR TITLE
Implement various API endpionts

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,6 +4,98 @@ info:
   description: This API provides the interface into the data to find out how much of a dog a player might be
   version: 1.0.0
 paths:
+  /character/profile:
+    get:
+      summary: Get warmane profile data
+      description: |
+        This is effectively just a passthrough to warmane.com's JSON API. It seems to have
+        pretty strict rate limits on it, so it may not always be reliable.
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: realm
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully retrieved profile from warmane.com
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  online:
+                    type: boolean
+                  class:
+                    type: string
+                    enum:
+                      [
+                        Druid,
+                        Hunter,
+                        Mage,
+                        Paladin,
+                        Priest,
+                        Rogue,
+                        Shaman,
+                        Warlock,
+                        Warrior,
+                      ]
+                  race:
+                    type: string
+                    enum:
+                      [
+                        Dwarf,
+                        "Night Elf",
+                        Gnome,
+                        Human,
+                        Orc,
+                        Undead,
+                        Tauren,
+                        BloodElf,
+                        Draenei,
+                      ]
+                  gender:
+                    type: string
+                    enum: [Male, Female]
+                  talents:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tree:
+                          type: string
+                        points:
+                          type: array
+                          items:
+                            type: number
+                  professions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        item:
+                          type: string
+                        transmog:
+                          type: string
+                  equipment:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        item:
+                          type: string
+                        transmog:
+                          type: string
+
   /character:
     get:
       summary: Get Warmane character metadata
@@ -41,83 +133,10 @@ paths:
                     type: string
                   total_games_played:
                     type: string
-                  last_crawled:
-                    type: string
-                  error:
-                    type: object
-                  warmane:
-                    type: object
-                    properties:
-                      online:
-                        type: boolean
-                      class:
-                        type: string
-                        enum:
-                          [
-                            Druid,
-                            Hunter,
-                            Mage,
-                            Paladin,
-                            Priest,
-                            Rogue,
-                            Shaman,
-                            Warlock,
-                            Warrior,
-                          ]
-                      race:
-                        type: string
-                        enum:
-                          [
-                            Dwarf,
-                            "Night Elf",
-                            Gnome,
-                            Human,
-                            Orc,
-                            Undead,
-                            Tauren,
-                            BloodElf,
-                            Draenei,
-                          ]
-                      gender:
-                        type: string
-                        enum: [Male, Female]
-                      talents:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            tree:
-                              type: string
-                            points:
-                              type: array
-                              items:
-                                type: number
-                      professions:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            item:
-                              type: string
-                            transmog:
-                              type: string
-                      equipment:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            item:
-                              type: string
-                            transmog:
-                              type: string
 
-  /character/crawl-status:
+  /character/crawl-state:
     get:
-      summary: Get the crawler status
+      summary: Get the crawler state
       description: |
         The crawler is highly constrained on how frequent it can be run. Clients will need
         to know when the last time it ran is, and when it is finished so it can know when

--- a/src/api/validators.ts
+++ b/src/api/validators.ts
@@ -13,3 +13,17 @@ export const getCharacterSchema = Joi.object<GetCharacterRequestParams>({
     .valid(...Realms)
     .required(),
 }).required();
+
+export interface getMatchesParams {
+  name: CharacterName;
+  realm: Realm;
+  continuation_token: string;
+}
+
+export const getMatchesSchema = Joi.object<getMatchesParams>({
+  name: Joi.string().valid().required(),
+  realm: Joi.string()
+    .valid(...Realms)
+    .required(),
+  continuation_token: Joi.string().optional(),
+}).required();

--- a/src/crawler.test.ts
+++ b/src/crawler.test.ts
@@ -1,6 +1,6 @@
 import { GetCharacterRequestParams } from "./api/validators";
 import { handleCrawlerRequests } from "./crawler";
-import { matchDetailsStore } from "./db/documentStoreV2";
+import { crawlerStateStore, matchDetailsStore } from "./db/documentStoreV2";
 import { MatchDetails, WarmaneCrawler } from "./lib/crawler/crawler";
 import { Realm } from "./lib/types";
 
@@ -45,7 +45,9 @@ describe("crawler lambda handler tests", () => {
     WarmaneCrawler.prototype.fetchAllMatchDetails = crawlerMock;
 
     const databaseMock = jest.fn();
+    const crawlerStateStoreMock = jest.fn();
     matchDetailsStore.upsert = databaseMock;
+    crawlerStateStore.upsert = crawlerStateStoreMock;
 
     const requests: GetCharacterRequestParams[] = [
       {

--- a/src/integration_tests/dynamo.integration.test.ts
+++ b/src/integration_tests/dynamo.integration.test.ts
@@ -1,4 +1,4 @@
-import { matchDetailsStore } from "../db/documentStoreV2";
+import { characterMetaStore, matchDetailsStore } from "../db/documentStoreV2";
 import { MatchDetails } from "../lib/crawler/crawler";
 
 describe("dynamo integration tests", () => {
@@ -56,5 +56,28 @@ describe("dynamo integration tests", () => {
         })
       )
     );
+  });
+
+  describe("CRUD on character meta table", () => {
+    test("it does the thing", async () => {
+      await characterMetaStore.upsert({
+        id: "testguy@Blackrock",
+        realm: "Blackrock",
+      });
+
+      const meta = await characterMetaStore.get({
+        id: "testguy@Blackrock",
+        // documentKey: "testguy@Blackrock",
+      });
+
+      expect(meta).toMatchObject({
+        id: "testguy@Blackrock",
+      });
+
+      await characterMetaStore.deletePermanently({
+        id: "testguy@Blackrock",
+        documentKey: "testguy@Blackrock",
+      });
+    });
   });
 });

--- a/src/lib/warmane_client/client.ts
+++ b/src/lib/warmane_client/client.ts
@@ -63,3 +63,25 @@ export async function getCharacterProfile(params: {
   );
   return response.data;
 }
+
+export async function checkCharacterExists(params: {
+  name: string;
+  realm: string;
+}): Promise<boolean> {
+  const { name, realm } = params;
+  const userAgent = randomUserAgent();
+  const response = await axios.get<string>(
+    `http://armory.warmane.com/character/${name}/${realm}/summary`,
+    {
+      headers: {
+        "User-Agent": userAgent,
+      },
+    }
+  );
+  if (
+    response.data.includes("The character you are looking for does not exist")
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,9 +2,13 @@ import Router from "@koa/router";
 import Koa from "koa";
 import { ApiGatewayContext } from "./middleware";
 import createError from "http-errors";
-import getCharacterMetadata from "./api/getCharacterMetadata";
-import { getCharacterSchema } from "./api/validators";
+import { getCharacterSchema, getMatchesSchema } from "./api/validators";
 import { requestCrawl } from "./lib/sqs/sqs_producer";
+import {
+  checkCharacterExists,
+  getCharacterProfile,
+} from "./lib/warmane_client/client";
+import { characterMetaStore, crawlerStateStore } from "./db/documentStoreV2";
 
 /**
  * ApiContext can be used to type a ctx argument for a function
@@ -18,18 +22,111 @@ export type ApiContext = Koa.ParameterizedContext<
   unknown
 >;
 
-export const router = new Router<Koa.DefaultState, ApiGatewayContext>();
+const router = new Router<Koa.DefaultState, ApiGatewayContext>();
 
+/**
+ * handles an API request to invoke the crawler. This will set the crawler state
+ * to pending and send a message to SQS to request the crawler to run.
+ */
 async function crawl(ctx: ApiContext) {
   const result = getCharacterSchema.validate(ctx.request.body);
   if (result.error) {
     throw createError(400, result.error.message);
   }
-  await requestCrawl(result.value);
+
+  const { name, realm } = result.value;
+  const characterExists = await checkCharacterExists({
+    name,
+    realm,
+  });
+
+  if (!characterExists) {
+    throw createError(404, "Character not found");
+  }
+
+  await crawlerStateStore.upsert({
+    id: `${name}@${realm}`,
+    state: "pending",
+  });
+
+  await requestCrawl({
+    name,
+    realm,
+  });
+
   ctx.body = {
-    status: "pending",
+    state: "pending",
   };
 }
 
+// TODO: I think these operations should be separate.
+// getting character profile data seems to be EXTREMELY rate limited
+// also I think i need to go with the original design and make the crawler status a separate type
+async function getCharacterMetadata(ctx: ApiContext) {
+  const params = getCharacterSchema.validate(ctx.query);
+  if (params.error) {
+    throw createError.BadRequest(params.error.message);
+  }
+  const { name, realm } = params.value;
+
+  const metadata = await characterMetaStore.get({
+    id: `${name}@${realm}`,
+  });
+
+  if (!metadata) {
+    throw createError.NotFound("Character metadata not found");
+  }
+
+  ctx.body = metadata;
+}
+
+async function getCharacterProfileData(ctx: ApiContext) {
+  const params = getCharacterSchema.validate(ctx.query);
+  if (params.error) {
+    throw createError.BadRequest(params.error.message);
+  }
+  const { name, realm } = params.value;
+
+  const profile = await getCharacterProfile({
+    name,
+    realm,
+  });
+
+  ctx.body = profile;
+}
+
+async function getMatches(ctx: ApiContext) {
+  const params = getMatchesSchema.validate(ctx.query);
+  if (params.error) {
+    throw createError.BadRequest(params.error.message);
+  }
+  const { name, realm } = params.value;
+
+  const matches = await characterMetaStore.list({
+    id: `${name}@${realm}`,
+    continuationToken: params.value.continuation_token,
+  });
+
+  ctx.body = matches;
+}
+
+async function getCrawlerState(ctx: ApiContext) {
+  const params = getMatchesSchema.validate(ctx.query);
+  if (params.error) {
+    throw createError.BadRequest(params.error.message);
+  }
+  const { name, realm } = params.value;
+  const crawlerState = await crawlerStateStore.get({ id: `${name}@${realm}` });
+  if (!crawlerState) {
+    throw createError.NotFound("Crawler state not found");
+  }
+  ctx.body = crawlerState;
+}
+
 router.get("/character", getCharacterMetadata);
+router.get("/character/profile", getCharacterProfileData);
+router.get("/character/matches", getMatches);
+router.get("/character/crawl-state", getCrawlerState);
 router.post("/crawl", crawl);
+
+export { router };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,7 +8,11 @@ import {
   checkCharacterExists,
   getCharacterProfile,
 } from "./lib/warmane_client/client";
-import { characterMetaStore, crawlerStateStore } from "./db/documentStoreV2";
+import {
+  characterMetaStore,
+  crawlerStateStore,
+  matchDetailsStore,
+} from "./db/documentStoreV2";
 
 /**
  * ApiContext can be used to type a ctx argument for a function
@@ -59,9 +63,6 @@ async function crawl(ctx: ApiContext) {
   };
 }
 
-// TODO: I think these operations should be separate.
-// getting character profile data seems to be EXTREMELY rate limited
-// also I think i need to go with the original design and make the crawler status a separate type
 async function getCharacterMetadata(ctx: ApiContext) {
   const params = getCharacterSchema.validate(ctx.query);
   if (params.error) {
@@ -102,7 +103,7 @@ async function getMatches(ctx: ApiContext) {
   }
   const { name, realm } = params.value;
 
-  const matches = await characterMetaStore.list({
+  const matches = await matchDetailsStore.list({
     id: `${name}@${realm}`,
     continuationToken: params.value.continuation_token,
   });


### PR DESCRIPTION
## Background
API endpoints implemented

- get /character
- get /character/profile
- get /character/matches
- get /character/crawl-state

This should be pretty close to everything that we need to have the front end start using it. The /character endpoint is kind of useless right now. The only thing that it should track is total games played but it's not actually saving that right now. That endpoint might be more useful later as we add features.

## How this was tested

<img width="868" alt="image" src="https://github.com/briansimoni/warmane-pvp-analytics-api/assets/11894935/33b7bae6-9b77-4b90-81f9-32db880bd549">

<img width="779" alt="image" src="https://github.com/briansimoni/warmane-pvp-analytics-api/assets/11894935/c5ecd973-2183-4f60-a25a-a604def8aad6">

<img width="1174" alt="image" src="https://github.com/briansimoni/warmane-pvp-analytics-api/assets/11894935/ac4400fc-63c5-4148-8fc0-0218454df9da">

