### PR TITLE
Increase visibility timeout

### DIFF
--- a/infrastructure/sqs.tf
+++ b/infrastructure/sqs.tf
@@ -3,7 +3,7 @@ resource "aws_sqs_queue" "crawl_queue" {
   max_message_size           = 2048
   message_retention_seconds  = 86400
   receive_wait_time_seconds  = 10
-  visibility_timeout_seconds = 180
+  visibility_timeout_seconds = 900
   sqs_managed_sse_enabled    = true
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.warmane_crawler_queue_dlq.arn


### PR DESCRIPTION
## Background

Per 
- https://docs.aws.amazon.com/lambda/latest/operatorguide/sqs-retries.html
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html

I think the visibility timeout should be much longer since I expect the crawler to occasionally take a while. I don't want a retry to happen before the first attempt got a fair chance at completing.


## How this was tested
I didn't test.
