### PR TITLE
Add batchWrite

### DIFF
--- a/src/crawler.test.ts
+++ b/src/crawler.test.ts
@@ -44,9 +44,9 @@ describe("crawler lambda handler tests", () => {
     );
     WarmaneCrawler.prototype.crawl = crawlerMock;
 
-    const databaseMock = jest.fn();
+    const matchDetailsStoreMock = jest.fn();
     const crawlerStateStoreMock = jest.fn();
-    matchDetailsStore.upsert = databaseMock;
+    matchDetailsStore.batchWrite = matchDetailsStoreMock;
     crawlerStateStore.upsert = crawlerStateStoreMock;
 
     const requests: GetCharacterRequestParams[] = [
@@ -61,6 +61,6 @@ describe("crawler lambda handler tests", () => {
     ];
     await handleCrawlerRequests(requests);
     expect(crawlerMock).toHaveBeenCalledTimes(2);
-    expect(databaseMock).toHaveBeenCalledTimes(4);
+    expect(matchDetailsStoreMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -74,12 +74,8 @@ export async function handleCrawlerRequests(
         realm: req.realm,
       });
 
-      const databaseWrites = matchDetails.map((match) =>
-        matchDetailsStore.upsert(match)
-      );
-
       logger.info(`crawling completed for ${req.name} on ${req.realm}`);
-      await Promise.all(databaseWrites);
+      await matchDetailsStore.batchWrite(matchDetails);
       logger.info(
         `crawler results saved successfully for ${req.name} on ${req.realm}`
       );

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -74,7 +74,9 @@ export async function handleCrawlerRequests(
         realm: req.realm,
       });
 
-      logger.info(`crawling completed for ${req.name} on ${req.realm}`);
+      logger.info(
+        `crawling completed for ${req.name} on ${req.realm}. ${matchDetails.length} games found`
+      );
       await matchDetailsStore.batchWrite(matchDetails);
       logger.info(
         `crawler results saved successfully for ${req.name} on ${req.realm}`

--- a/src/db/documentStoreV2.ts
+++ b/src/db/documentStoreV2.ts
@@ -1,13 +1,5 @@
-import {
-  DynamoDBClient,
-  PutItemCommand,
-  PutRequest,
-} from "@aws-sdk/client-dynamodb";
-import {
-  BatchWriteCommandInput,
-  DynamoDBDocument,
-  PutCommandInput,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { config } from "../config";
 import { CharacterId, CharacterName, MatchDetails, Realm } from "../lib/types";
 

--- a/src/integration_tests/dynamo.integration.test.ts
+++ b/src/integration_tests/dynamo.integration.test.ts
@@ -32,10 +32,7 @@ describe("dynamo integration tests", () => {
     };
 
     // create
-    await Promise.all([
-      matchDetailsStore.upsert(matchDetails),
-      matchDetailsStore.upsert(matchDetails2),
-    ]);
+    await matchDetailsStore.batchWrite([matchDetails, matchDetails2]);
 
     // read a list
     const list = await matchDetailsStore.list({ id });


### PR DESCRIPTION
## Background
I noticed that Dynamo was throttling requests when I tried to make 1000 requests all at one time. I implemented a batchWrite method to the DocumentStore which uses the Dynamo BatchWrite command.

## How this was tested
I ran it locally and checked the graphs of Dynamo in the console. It seems fine to me.
